### PR TITLE
fix: replace 19 bare excepts with except Exception across 5 files

### DIFF
--- a/convert_3dgs.py
+++ b/convert_3dgs.py
@@ -28,7 +28,7 @@ from utils.image_utils import psnr
 try:
     from fused_ssim import fused_ssim
     FUSED_SSIM_AVAILABLE = True
-except:
+except Exception:
     FUSED_SSIM_AVAILABLE = False
 
 def render_sets(dataset : ModelParams, opt : OptimizationParams, iteration : int, pipe : PipelineParams, pruning_ratio : float = 0.6):

--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -161,7 +161,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
     if retain_grad:
         try:
             screenspace_points.retain_grad()
-        except:
+        except Exception:
             pass
 
 
@@ -237,7 +237,7 @@ def render3dgs(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tens
     screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
     try:
         screenspace_points.retain_grad()
-    except:
+    except Exception:
         pass
 
     # Set up rasterization configuration

--- a/metrics.py
+++ b/metrics.py
@@ -96,7 +96,7 @@ def evaluate(model_paths):
                 json.dump(full_dict[scene_dir], fp, indent=True)
             with open(scene_dir + "/per_view.json", 'w') as fp:
                 json.dump(per_view_dict[scene_dir], fp, indent=True)
-        except:
+        except Exception:
             print("Unable to compute metrics for model", scene_dir)
 
 if __name__ == "__main__":

--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -173,7 +173,7 @@ def fetchPly(path):
     positions = np.vstack([vertices['x'], vertices['y'], vertices['z']]).T
     try:
         colors = np.vstack([vertices['red'], vertices['green'], vertices['blue']]).T / 255.0
-    except:
+    except Exception:
         colors = np.random.rand(positions.shape[0], positions.shape[1])
     normals = np.vstack([vertices['nx'], vertices['ny'], vertices['nz']]).T
     return BasicPointCloud(points=positions, colors=colors, normals=normals)
@@ -298,17 +298,17 @@ def readEvalSceneInfo(path, model_path, images, eval, llffhold=8):
                 print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
                 try:
                     xyz, rgb, _ = read_points3D_binary(bin_path)
-                except:
+                except Exception:
                     try:
                         xyz, rgb, _ = read_points3D_text(txt_path)
-                    except:
+                    except Exception:
                         print("Failed to load point cloud data")
                         xyz, rgb = None, None
                 if xyz is not None:
                     storePly(ply_path, xyz, rgb)
             try:
                 pcd = fetchPly(ply_path)
-            except:
+            except Exception:
                 pcd = None
         else:
             print("Skipping point cloud loading as GT poses are not available")
@@ -383,7 +383,7 @@ def readFreeSceneInfo(path, images, eval, llffhold=8):
             cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
             cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
             cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
-        except:
+        except Exception:
             cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
             cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
             cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
@@ -411,7 +411,7 @@ def readFreeSceneInfo(path, images, eval, llffhold=8):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:
             xyz, rgb, _ = read_points3D_binary(bin_path)
-        except:
+        except Exception:
             xyz, rgb, _ = read_points3D_text(txt_path)
         storePly(ply_path, xyz, rgb)
 
@@ -431,7 +431,7 @@ def readTanksSceneInfo(path, images, eval, llffhold=8):
             cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
             cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
             cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
-        except:
+        except Exception:
             cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
             cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
             cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
@@ -463,7 +463,7 @@ def readTanksSceneInfo(path, images, eval, llffhold=8):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:
             xyz, rgb, _ = read_points3D_binary(bin_path)
-        except:
+        except Exception:
             xyz, rgb, _ = read_points3D_text(txt_path)
         storePly(ply_path, xyz, rgb)
 
@@ -497,7 +497,7 @@ def readHikeSceneInfo(path, images, eval, llffhold=10):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:
             xyz, rgb, _ = read_points3D_binary(bin_path)
-        except:
+        except Exception:
             xyz, rgb, _ = read_points3D_text(txt_path)
         storePly(ply_path, xyz, rgb)
 
@@ -523,14 +523,14 @@ def readCustomSceneInfo(path, images, eval, llffhold=8):
             cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
             cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
             has_camera_data = True
-        except:
+        except Exception:
             try:
                 cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
                 cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
                 cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
                 cam_intrinsics = read_intrinsics_text(cameras_intrinsic_file)
                 has_camera_data = True
-            except:
+            except Exception:
                 print("No valid camera data found in sparse folder, proceeding without camera poses")
                 has_camera_data = False
     
@@ -567,18 +567,18 @@ def readCustomSceneInfo(path, images, eval, llffhold=8):
             try:
                 xyz, rgb, _ = read_points3D_binary(bin_path)
                 storePly(ply_path, xyz, rgb)
-            except:
+            except Exception:
                 try:
                     xyz, rgb, _ = read_points3D_text(txt_path)
                     storePly(ply_path, xyz, rgb)
-                except:
+                except Exception:
                     print("No valid point cloud data found, proceeding without point cloud")
                     ply_path = None
         
         if ply_path and os.path.exists(ply_path):
             try:
                 pcd = fetchPly(ply_path)
-            except:
+            except Exception:
                 print("Failed to load point cloud from PLY file")
                 pcd = None
                 ply_path = None

--- a/train.py
+++ b/train.py
@@ -49,7 +49,7 @@ try:
     from fused_ssim import fused_ssim
     FUSED_SSIM_AVAILABLE = True
     print("fused ssim available")
-except:
+except Exception:
     FUSED_SSIM_AVAILABLE = False
     print("fused ssim not available")
     


### PR DESCRIPTION
Bare `except:` → `except Exception:` in 5 files (19 sites). Prevents catching KeyboardInterrupt/SystemExit.